### PR TITLE
feat: new route for accessing different grants by URL

### DIFF
--- a/cypress/integration/pages/grant.spec.js
+++ b/cypress/integration/pages/grant.spec.js
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+context('Grant page', () => {
+  before(() => {
+    cy.setHackneyCookie(true);
+  });
+
+  describe('page content', () => {
+    it('displays correct name in the heading', () => {
+      cy.visit('/grant/arg-3/step/1');
+
+      cy.get('[data-testid=page-heading]').should(
+        'contain',
+        'Additional Restrictions Grant – Round 3'
+      );
+    });
+  });
+});

--- a/grants/grants.test.ts
+++ b/grants/grants.test.ts
@@ -1,0 +1,15 @@
+import { getGrantBySlug } from './grants';
+
+describe('grants', () => {
+  describe('#getGrantBySlug', () => {
+    it('should throw if an unknown slug is proviuded', () => {
+      expect(() => getGrantBySlug('unknown-grant')).toThrow();
+    });
+
+    it('should return a grant with a valid slug', () => {
+      const { name } = getGrantBySlug('arg-3');
+
+      expect(name).toEqual(expect.any(String));
+    });
+  });
+});

--- a/grants/grants.test.ts
+++ b/grants/grants.test.ts
@@ -1,9 +1,10 @@
+import { NotFoundError } from '../utils/errors';
 import { getGrantBySlug } from './grants';
 
 describe('grants', () => {
   describe('#getGrantBySlug', () => {
     it('should throw if an unknown slug is proviuded', () => {
-      expect(() => getGrantBySlug('unknown-grant')).toThrow();
+      expect(() => getGrantBySlug('unknown-grant')).toThrow(NotFoundError);
     });
 
     it('should return a grant with a valid slug', () => {

--- a/grants/grants.tsx
+++ b/grants/grants.tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+
+type Grant = {
+  name: string;
+  description: ReactElement;
+};
+
+const grants: Map<string, Grant> = new Map([
+  [
+    'arg-3',
+    {
+      name: 'Additional Restrictions Grant – Round 3',
+      description: (
+        <>
+          <p>
+            This is the JSX-based <strong>description</strong> for ARG Round 3
+          </p>
+        </>
+      ),
+    },
+  ],
+]);
+
+export const getGrantBySlug = (slug: string): Grant => {
+  if (!grants.has(slug)) {
+    throw new Error(`Unable to find a grant with the slug ${slug}`);
+  }
+
+  return grants.get(slug);
+};

--- a/grants/grants.tsx
+++ b/grants/grants.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react';
+import { NotFoundError } from '../utils/errors';
 
-type Grant = {
+export type Grant = {
   name: string;
   description: ReactElement;
 };
@@ -23,7 +24,7 @@ const grants: Map<string, Grant> = new Map([
 
 export const getGrantBySlug = (slug: string): Grant => {
   if (!grants.has(slug)) {
-    throw new Error(`Unable to find a grant with the slug ${slug}`);
+    throw new NotFoundError(`Unable to find a grant with the slug ${slug}`);
   }
 
   return grants.get(slug);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preint-test": "yarn build",
     "unit-test": "jest",
     "unit-test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
-    "lint": "eslint . --ext .js,.jsx && echo 'Lint complete.'",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx && echo 'Lint complete.'",
     "format": "prettier '**/*.{js,jsx,css,scss,md}' --write --list-different",
     "dbmigrate": "db-migrate --migrations-dir 'db/migrations/'",
     "dbmigratetest": "db-migrate --migrations-dir 'db/migrations/' -e test",

--- a/pages/grant/[slug]/step/[id].tsx
+++ b/pages/grant/[slug]/step/[id].tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import ErrorPage from 'next/error';
 
-import { getGrantBySlug, Grant } from '../../../../grants/grants';
+import { getGrantBySlug } from '../../../../grants/grants';
 import { GetServerSideProps } from 'next';
 import { convertErrorToStatusCode } from '../../../../utils/errors';
 

--- a/pages/grant/[slug]/step/[id].tsx
+++ b/pages/grant/[slug]/step/[id].tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+import { getGrantBySlug } from '../../../../grants/grants';
+
+const GrantStep: React.FC = () => {
+  const { query } = useRouter();
+
+  const slug = Array.isArray(query.slug) ? query.slug[0] : query.slug;
+  const id = Array.isArray(query.id) ? query.id[0] : query.id;
+
+  const grant = getGrantBySlug(slug);
+
+  return (
+    <>
+      <h1 data-testid="page-heading">{grant.name}</h1>
+
+      {grant.description}
+
+      <dl>
+        <dt>Step ID:</dt>
+        <dd>{id}</dd>
+      </dl>
+    </>
+  );
+};
+
+export const getServerSideProps = () => {
+  return {
+    props: {},
+  };
+};
+
+export default GrantStep;

--- a/pages/grant/[slug]/step/[id].tsx
+++ b/pages/grant/[slug]/step/[id].tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import { useRouter } from 'next/router';
+import ErrorPage from 'next/error';
 
-import { getGrantBySlug } from '../../../../grants/grants';
+import { getGrantBySlug, Grant } from '../../../../grants/grants';
+import { GetServerSideProps } from 'next';
+import { convertErrorToStatusCode } from '../../../../utils/errors';
 
-const GrantStep: React.FC = () => {
+const GrantStep: React.FC<{ slug: string; statusCode: number }> = ({
+  slug,
+  statusCode = 200,
+}) => {
   const { query } = useRouter();
 
-  const slug = Array.isArray(query.slug) ? query.slug[0] : query.slug;
   const id = Array.isArray(query.id) ? query.id[0] : query.id;
+
+  if (statusCode >= 400) {
+    return <ErrorPage statusCode={statusCode} />;
+  }
 
   const grant = getGrantBySlug(slug);
 
@@ -25,10 +34,31 @@ const GrantStep: React.FC = () => {
   );
 };
 
-export const getServerSideProps = () => {
-  return {
-    props: {},
-  };
+export const getServerSideProps: GetServerSideProps = async ({
+  query,
+  res,
+}) => {
+  const slug = Array.isArray(query.slug) ? query.slug[0] : query.slug;
+
+  try {
+    getGrantBySlug(slug);
+
+    return {
+      props: {
+        slug,
+      },
+    };
+  } catch (error) {
+    const statusCode = convertErrorToStatusCode(error);
+
+    res.statusCode = statusCode;
+
+    return {
+      props: {
+        statusCode,
+      },
+    };
+  }
 };
 
 export default GrantStep;

--- a/utils/errors.test.ts
+++ b/utils/errors.test.ts
@@ -1,0 +1,11 @@
+import { convertErrorToStatusCode, NotFoundError } from './errors';
+
+describe('custom errors', () => {
+  describe('#convertErrorToStatusCode()', () => {
+    it('should return 404 if a NotFoundError is provided', () => {
+      expect(convertErrorToStatusCode(new NotFoundError('Not found'))).toEqual(
+        404
+      );
+    });
+  });
+});

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,0 +1,14 @@
+export class NotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
+
+export const convertErrorToStatusCode = (error: Error) => {
+  if (error instanceof NotFoundError) {
+    return 404;
+  }
+
+  return 500;
+};


### PR DESCRIPTION
**What**  
Introduces a new URL (`/grants/[slug]/step/[id]`) for accessing different grants within a single application. Also adds some custom error types (`NotFoundError`) to map onto custom status codes.
