### PR TITLE
fix: depend on OWASP job to deploy to staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,12 +149,12 @@ workflows:
           context: api-assume-role-regen-apps-staging-context
           requires:
             - install-dependencies-and-test
+            - owasp-zap-baseline-scan
           filters:
             branches:
               only: main
       - build-deploy-staging:
           requires:
-            - install-dependencies-and-test
             - assume-role-staging
           filters:
             branches:


### PR DESCRIPTION
**What**  
Blocks the assume role job (and ultimately the deploy job) on the success of the OWASP Baseline scan job.

**Why**  
Only deploy once we have run the security checks.
