### PR TITLE
Corrected database version as the serverless version appears behind t…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,13 @@ workflows:
             - owasp-zap-baseline-scan
           filters:
             branches:
-              only: fix/correct-db-version
+              only: main
       - build-deploy-staging:
           requires:
             - assume-role-staging
           filters:
             branches:
-              only: fix/correct-db-version
+              only: main
       # - permit-deploy-production:
       #     type: approval
       #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,13 @@ workflows:
             - owasp-zap-baseline-scan
           filters:
             branches:
-              only: main
+              only: fix/correct-db-version
       - build-deploy-staging:
           requires:
             - assume-role-staging
           filters:
             branches:
-              only: main
+              only: fix/correct-db-version
       # - permit-deploy-production:
       #     type: approval
       #     requires:

--- a/serverless.yml
+++ b/serverless.yml
@@ -163,7 +163,7 @@ resources:
         DBName: ${self:custom.dbname}
         DeletionProtection: true
         Engine: 'postgres'
-        EngineVersion: '11.7'
+        EngineVersion: '11.12'
         MasterUsername: ${env:MASTER_USERNAME}
         MasterUserPassword: ${env:MASTER_USER_PASSWORD}
         MultiAZ: true


### PR DESCRIPTION
**What**  
Changed Postgres DB version in serverless to 11.12.

**Why**  
This is the version in RDS. The version in our serverless.yml was 11.7 since creation. However, it's started erroring trying to 'upgrade' from 11.12 to 11.7 since enabling database protection. 

We don't want to downgrade the database version so I'm changing the serverless config to match the actual.

![image](https://user-images.githubusercontent.com/80220779/150765813-19de289e-709b-4158-a477-8f6ce402f746.png)
