### PR TITLE
feat: add a local filesystem gateway to ease local dev

### DIFF
--- a/lib/gateways/__tests__/local-filesystem.test.js
+++ b/lib/gateways/__tests__/local-filesystem.test.js
@@ -1,0 +1,17 @@
+import createGateway from '../local-filesystem';
+
+describe('local filesystem gateway', () => {
+  const gateway = createGateway();
+  it('should return a local URL path to upload the file to', () => {
+    expect(
+      gateway.createUploadUrl('dropboxId', 'documentId', 'fileName')
+    ).toEqual({
+      url: '/api/local-file-upload/dropboxId/documentId/fileName',
+      fields: {},
+    });
+  });
+
+  it('should return a local path to download the file', () => {
+    expect(gateway.getDownloadUrl('key')).toEqual('/public/uploads/key');
+  });
+});

--- a/lib/gateways/local-filesystem.js
+++ b/lib/gateways/local-filesystem.js
@@ -1,0 +1,29 @@
+/**
+ * Gateway that provides documents that belong to dropboxes from Amazon S3.
+ */
+export default () => {
+  /**
+   * Creates a URL that can be used to upload a new document to the dropbox.
+   * @param {String} dropboxId the id of the dropbox
+   * @param {String} documentId the id of the new document
+   */
+  function createUploadUrl(dropboxId, documentId, fileName) {
+    console.log('Generating pre-signed upload url', { dropboxId, documentId });
+
+    return {
+      url: `/api/local-file-upload/${dropboxId}/${documentId}/${fileName}`,
+      fields: {},
+    };
+  }
+
+  function getDownloadUrl(key) {
+    console.log('Generating pre-signed download url', { key });
+
+    return `/public/uploads/${key}`;
+  }
+
+  return {
+    createUploadUrl,
+    getDownloadUrl,
+  };
+};

--- a/lib/usecases/getSecureUploadUrl.js
+++ b/lib/usecases/getSecureUploadUrl.js
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import createGateway from '../gateways/s3';
+import createLocalFilesystemGateway from '../gateways/local-filesystem';
 import s3config from '../s3config';
 
 const documents = createGateway({
@@ -10,12 +11,19 @@ const documents = createGateway({
   },
 });
 
+const localDocuments = createLocalFilesystemGateway();
+
 export default async (dropboxId, fileName) => {
+  const shouldUseLocalStorage = process.env.ENV === 'local' ? true : false;
+
+  const documentsGateway = shouldUseLocalStorage ? localDocuments : documents;
+
   const documentId = nanoid(15);
-  const uploadOptions = await documents.createUploadUrl(
+  const uploadOptions = await documentsGateway.createUploadUrl(
     dropboxId,
     documentId,
     fileName
   );
+
   return { documentId, ...uploadOptions };
 };

--- a/lib/usecases/getSecureUploadUrl.test.js
+++ b/lib/usecases/getSecureUploadUrl.test.js
@@ -1,8 +1,19 @@
 import getSecureUploadUrl from './getSecureUploadUrl';
 
+jest.mock('../gateways/s3', () => () => ({
+  createUploadUrl: async () => {
+    return {
+      url: 'https://s3.amazonaws.com/document-id',
+      fields: {},
+    };
+  },
+}));
+
 describe('get secure upload URL usecase', () => {
   let initialEnv;
   beforeEach(() => {
+    jest.resetAllMocks();
+
     initialEnv = {
       ...process.env,
     };

--- a/lib/usecases/getSecureUploadUrl.test.js
+++ b/lib/usecases/getSecureUploadUrl.test.js
@@ -1,0 +1,40 @@
+import getSecureUploadUrl from './getSecureUploadUrl';
+
+describe('get secure upload URL usecase', () => {
+  let initialEnv;
+  beforeEach(() => {
+    initialEnv = {
+      ...process.env,
+    };
+  });
+
+  afterEach(() => {
+    process.env = initialEnv;
+  });
+
+  it('should use local filesystem gateway if the ENV environment variable is "local"', async () => {
+    process.env.ENV = 'local';
+
+    await expect(getSecureUploadUrl('dropbox-id', 'filename')).resolves.toEqual(
+      {
+        documentId: expect.any(String),
+        url: expect.stringMatching(
+          /\/api\/local-file-upload\/dropbox-id\/.*?\/filename/
+        ),
+        fields: {},
+      }
+    );
+  });
+
+  it('should use the S3 if the ENV environment variable is anything other than "local"', async () => {
+    process.env.ENV = 'production';
+
+    await expect(getSecureUploadUrl('dropbox-id', 'filename')).resolves.toEqual(
+      {
+        documentId: expect.any(String),
+        url: expect.stringContaining('https://s3.amazonaws.com/'),
+        fields: expect.any(Object),
+      }
+    );
+  });
+});

--- a/pages/api/local-file-upload/[...params].ts
+++ b/pages/api/local-file-upload/[...params].ts
@@ -1,0 +1,17 @@
+import { NextApiHandler } from 'next';
+
+const handler: NextApiHandler = (req, res) => {
+  const shouldUseLocalStorage = process.env.ENV === 'local' ? true : false;
+
+  if (!shouldUseLocalStorage) {
+    // This route doesn't exist in non-local environments, so return a 404
+    res.statusCode = 404;
+    res.end();
+    return;
+  }
+
+  // At the moment, we don't particularly care about what is uploaded, we just want to return a nice 200 HTTP response
+  res.end();
+};
+
+export default handler;


### PR DESCRIPTION
**What**  
This PR introduces a new gateway that mimics the S3 gateway, and allows us to "upload" files locally. At the moment there is no actual local upload functionality, but it does allow the app to work normally without having to change application code during development.

