### PR TITLE
fix: conditionally join for grant officers when listing applications

### DIFF
--- a/lib/usecases/listApplications.js
+++ b/lib/usecases/listApplications.js
@@ -71,12 +71,16 @@ const listApplications = ({ getDbInstance, getListGrantOfficers }) => async ({
       ON ec.grant_application_id = ga.id
     JOIN application_assessment AS aa ON
       ga.id = aa.grant_application_id
-    JOIN (
+    ${
+      grantOfficerFilter.length > 0
+        ? `JOIN (
       SELECT DISTINCT grant_application_id
         FROM application_history
         WHERE user_recorded IN ($(grantOfficerFilter:list))
       ) AS ah
-      ON ga.id = ah.grant_application_id
+      ON ga.id = ah.grant_application_id`
+        : ''
+    }
     JOIN application_state AS state ON
       aa.application_state_id = state.id
     JOIN business_category as bc ON

--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -40,9 +40,9 @@ function createContainerAndSpies(numberOfApplicationsInResponse) {
         any: databaseSpy,
       };
     },
-    getListGrantOfficers() {
+    getListGrantOfficers: jest.fn(() => {
       return listGrantOfficersSpy;
-    },
+    }),
   };
   return { databaseSpy, container, expectedGrantOfficers };
 }
@@ -97,6 +97,26 @@ describe('listApplications', () => {
         pageSize: 10,
         offset: 0,
       })
+    );
+  });
+
+  test('does not join the grant officers data if the grant officers list is empty', async () => {
+    const { databaseSpy, container } = createContainerAndSpies(0);
+
+    container.getListGrantOfficers.mockImplementationOnce(() => {
+      return () => ({
+        grantOfficers: [],
+      });
+    });
+
+    const { error } = await listApplications(container)({});
+
+    expect(error).toBeNull();
+    expect(databaseSpy).toHaveBeenCalledWith(
+      expect.not.stringContaining(
+        'WHERE user_recorded IN ($(grantOfficerFilter:list))'
+      ),
+      expect.anything()
     );
   });
 


### PR DESCRIPTION
**What**  
The admin crashes when there's no data because it tries to join on the grant officers list (which is empty). This prevents that happening, which is more convenient for local dev.