### PR TITLE
Changed payment CSV download process 

### DIFF
--- a/pages/admin/grant/[slug]/index.tsx
+++ b/pages/admin/grant/[slug]/index.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { string } from 'prop-types';
 import { useState } from 'react';
 import ApplicationsList from '../../../../components/ApplicationsList/ApplicationsList';
 import ErrorMessage from '../../../../components/ErrorMessage/ErrorMessage';
@@ -15,21 +16,6 @@ const AdminManageGrantPage = (props) => {
   const grant = getGrantBySlug(slug);
 
   const canDownloadCsvs = props.groups.includes(props.csvDownloadGroup);
-
-  const handlePaymentsExport = async (e) => {
-    try {
-      setPaymentsExportError(null);
-
-      const csvData = await patchApplications({
-        grantType: slug,
-      });
-
-      window.open(encodeURI(`data:text/csv;charset=utf-8,${csvData}`));
-    } catch (e) {
-      e.response.status = 400;
-      setPaymentsExportError(e.response.data);
-    }
-  };
 
   return (
     <>
@@ -82,13 +68,16 @@ const AdminManageGrantPage = (props) => {
 
           {paymentsExportError && <ErrorMessage text={paymentsExportError} />}
 
-          <button
+          <a
+            href={`/api/csv/applications/payments?grantType=${slug}`}
+            target="_blank"
+            role="button"
+            draggable="false"
             className="govuk-button govuk-button--secondary govuk-!-margin-right-1"
             data-module="govuk-button"
-            onClick={handlePaymentsExport}
           >
             Export Panel Approved Payments
-          </button>
+          </a>
         </>
       )}
     </>

--- a/pages/api/csv/applications/payments/index.js
+++ b/pages/api/csv/applications/payments/index.js
@@ -1,0 +1,35 @@
+import * as HttpStatus from 'http-status-codes';
+import AppContainer from '../../../../../containers/AppContainer';
+
+export default async (req, res) => {
+  switch (req.method) {
+    case 'GET':
+      try {
+        const grantType = req.query.grantType;
+        if (!grantType) {
+          throw new Error("Missing 'grantType' parameter");
+        }
+
+        const container = AppContainer.getInstance();
+        const listApplicationsCSV = container.getPatchApplications();
+        res.statusCode = HttpStatus.OK;
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+        res.setHeader('Content-Disposition', 'filename=payments.csv');
+        const csvResult = await listApplicationsCSV({
+          grantType,
+        });
+        res.end(csvResult.csvString);
+      } catch (error) {
+        console.log('Patch Applications CSV error:', error);
+        res.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+        res.end(
+          JSON.stringify('Unable to generate a payment applications CSV')
+        );
+      }
+      break;
+
+    default:
+      res.statusCode = HttpStatus.BAD_REQUEST;
+      res.end(JSON.stringify('Invalid request method'));
+  }
+};


### PR DESCRIPTION
**What**  
This now calls a secured endpoint that will download the CSV in the same manner as the other. A GET call will return the data with the appropriate content-type.

**Why**  
It was using window.open() in JS before, passing in the CSV data as part of the URI. Aside from this not working on at least 2 Chromebooks, it would probably have issues with the length of data if it exceeded that allowed by a GET.
