### PR TITLE
Added validation to 2 Eligibility fields

### DIFF
--- a/components/Steps/additional-restrictions-grant/index.jsx
+++ b/components/Steps/additional-restrictions-grant/index.jsx
@@ -70,6 +70,7 @@ export const inputLabels = {
       ),
       validation: { required: true },
       validAnswer: 'Yes',
+      adminValidation: true,
     },
     servedLegalNotices: {
       label:
@@ -81,6 +82,7 @@ export const inputLabels = {
     businessIsTrading: {
       label: 'Is your business currently trading?',
       validation: { required: true },
+      adminValidation: true,
       validAnswer: 'Yes',
     },
     eligibleForOhlg: {


### PR DESCRIPTION
**What**  
Two fields in 'Eligibility Criteria' didn't have checkboxes for a grant officer to validate and confirm details are correct. Added.

**Why**  
Without these there's no way to log that fields entered by businesses have been validated.

