### PR TITLE
Don't allow access to endpoint that isn't required for normal admins.

### DIFF
--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -137,30 +137,6 @@ export default async (req, res) => {
       }
       break;
 
-    case 'PATCH':
-      try {
-        const container = AppContainer.getInstance();
-        const patchApplications = container.getPatchApplications();
-
-        res.statusCode = HttpStatus.OK;
-
-        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-        res.setHeader('Content-Disposition', 'filename=export.csv');
-
-        const patchResponse = await patchApplications({
-          author: getUserStringFromCookie(req.headers.cookie),
-          grantType: req.body.grantType,
-        });
-
-        res.end(patchResponse.csvString);
-      } catch (error) {
-        console.log('Applications patch error:', error);
-
-        res.statusCode = HttpStatus.BAD_REQUEST;
-        res.end(JSON.stringify(error.message));
-      }
-      break;
-
     default:
       res.statusCode = HttpStatus.BAD_REQUEST;
       res.end(JSON.stringify('Invalid request method'));

--- a/pages/api/csv/applications/payments/index.js
+++ b/pages/api/csv/applications/payments/index.js
@@ -1,6 +1,9 @@
 import * as HttpStatus from 'http-status-codes';
 import AppContainer from '../../../../../containers/AppContainer';
-import { getUserStringFromCookie } from '../../../../../utils/auth';
+import {
+  getUserStringFromCookie,
+  getUserFromCookie,
+} from '../../../../../utils/auth';
 
 export default async (req, res) => {
   switch (req.method) {
@@ -9,6 +12,12 @@ export default async (req, res) => {
         const grantType = req.query.grantType;
         if (!grantType) {
           throw new Error("Missing 'grantType' parameter");
+        }
+
+        const user = getUserFromCookie(req.headers.cookie);
+        if (!user.groups.includes(process.env.CSV_DOWNLOAD_GROUP)) {
+          res.statusCode = HttpStatus.FORBIDDEN;
+          res.end(JSON.stringify('Access forbidden'));
         }
 
         const container = AppContainer.getInstance();


### PR DESCRIPTION
**What**  
Restrict access to endpoint to only those who require.

**Why**  
Although this endpoint only returns data already visible to them as standard admin, it applies a patch and may in the future return other data. Restricting to only the user required.