### PR TITLE
Business rateable value should allow non-int characters

### DIFF
--- a/lib/usecases/validators.js
+++ b/lib/usecases/validators.js
@@ -80,7 +80,7 @@ const ohlgSchema = yup.object().shape({
       isBusinessStillTradingDateStopped: yup.string(),
       dateEstablished: yup.string(),
       businessSize: yup.string(),
-      businessRateableValue: yup.string().integer(),
+      businessRateableValue: yup.string(),
       businessWebsite: yup.string(),
     })
     .required(),


### PR DESCRIPTION
**What**  
Only occurring for OHLG; Business Rateable Value was enforcing an integer during validation which meant '55000.00' would fail validation. I have changed the validation to check for a string as per ARG, whilst the front-end still enforces a currency value to be entered.

**Why**  
Without this, people were able to enter '55000.00' and get to the summary, then submit and a generic error showed due to the validation error.
