### PR TITLE
Fixed bug after formidable upgrade

### DIFF
--- a/pages/api/urls/index.js
+++ b/pages/api/urls/index.js
@@ -32,7 +32,7 @@ export default async (req, res) => {
     });
 
     const { clientGeneratedId, fileName } = data.fields;
-    const fileType = await fileTypeFromFile(data?.files.file.path);
+    const fileType = await fileTypeFromFile(data?.files?.file.filepath);
 
     if (fileType && !allowedMimes.includes(fileType.mime))
       throw new Error('Disallowed mime type');


### PR DESCRIPTION
The filepath property changed since upgrading formidable. Corrected to use the new one. Without this file upload won't work.