### PR TITLE
Add allowed groups to main function to allow UI restrictions

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -65,6 +65,7 @@ functions:
       EMAIL_APPLICATION_RECEIVED_TEMPLATE_ID: ${env:EMAIL_APPLICATION_RECEIVED_TEMPLATE_ID}
       CSV_DOWNLOAD_GROUP: ${env:CSV_DOWNLOAD_GROUP}
       NEXT_PUBLIC_EQUALITIES_GOOGLE_FORM_URL: ${env:NEXT_PUBLIC_EQUALITIES_GOOGLE_FORM_URL}
+      ALLOWED_GROUPS: ${self:custom.allowed-groups.${self:provider.stage}}
 
   authorizer:
     name: ${self:service}-authorizer-${self:provider.stage}


### PR DESCRIPTION
**What**  
Add the allowed groups list to the main function to make it available for UI / Next.js restrictions.

**Why**  
Without this we can only restrict the front-end to the CSV Export group.
