### PR TITLE
Fixed issue exporting payment CSV where grant types were mixed

### DIFF
--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -15,6 +15,7 @@ const patchApplications =
         FROM grant_application
         WHERE
             grant_application.grant_type = $(grantType)
+            AND grant_application.id = grant_application_id
             AND payment_exported = false
             AND application_state_id = 2
         RETURNING grant_application_id


### PR DESCRIPTION
**What**  
The payment CSV was exporting all grant types when only the current grant type being viewed should be exported. The query behind this has been resolved by correctly applying a join.

**Why**  
Without this grant applications will be exported for both ARG and OHLG, setting all of them to exported; whereas it's required to do this separately as two different organisation units deal with these grant types.
