### PR TITLE
Allow already exported data to be exported

### DIFF
--- a/components/ApplicationGrantSelector/ApplicationGrantSelector.jsx
+++ b/components/ApplicationGrantSelector/ApplicationGrantSelector.jsx
@@ -5,7 +5,10 @@ import { stepKeys } from '../Steps';
 const ApplicationGrantSelector = ({ date, expirationDate }) => {
   return (
     <>
-      <OhlgGrantSelector date={date} expirationDate={expirationDate} />
+      <OhlgGrantSelector
+        date={new Date().getTime()}
+        expirationDate={'2022-03-19 00:00:00.001'}
+      />
       <ArgGrantSelector
         date={new Date().getTime()}
         expirationDate={'2022-02-15 00:00:00.001'}

--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -16,7 +16,7 @@ const patchApplications =
         WHERE
             grant_application.grant_type = $(grantType)
             AND grant_application.id = grant_application_id
-            AND payment_exported = false
+            AND payment_exported = true
             AND application_state_id = 2
         RETURNING grant_application_id
     ),


### PR DESCRIPTION
**What**  
Payments info can only be exported once. An issue occurred with a previous export running in incognito mode and we need to export the already exported data once. This will allow that.

**Why**  
To prevent users having to manually re-create the payment CSV.

**Anything else?**
Also changed the switch-off date for OHLG now it's been provided.
