### PR TITLE
Revert change once already-exported apps have been exported

### DIFF
--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -16,7 +16,7 @@ const patchApplications =
         WHERE
             grant_application.grant_type = $(grantType)
             AND grant_application.id = grant_application_id
-            AND payment_exported = true
+            AND payment_exported = false
             AND application_state_id = 2
         RETURNING grant_application_id
     ),


### PR DESCRIPTION
**What**  
Change to only export applications that have not previously been exported.

**Why**  
This logic was inverted to do a second export of payment data after one failed. It is now being set back to the correct value.
