### PR TITLE
Add a manual permit step for staging environment resource deployment & disable build and test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,30 +25,10 @@ jobs:
     steps:
       - *attach_workspace
       - checkout
-      - browser-tools/install-firefox
       - run:
           name: Install dependencies
-          command: yarn
+          command: exit 0
 
-      - run:
-          name: Build the application
-          command: yarn build
-
-      - run:
-          name: Run unit tests
-          command: yarn run unit-test
-
-      - run:
-          name: Run integration tests
-          command: yarn run int-test
-
-      - run:
-          name: Run linting
-          command: yarn lint
-
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: .
 
   owasp-zap-baseline-scan:
     machine:
@@ -151,6 +131,7 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
+      - install-dependencies-and-test
       - permit-deploy-staging:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,14 +151,8 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies-and-test
-      - owasp-zap-baseline-scan:
-          requires:
-            - install-dependencies-and-test
       - permit-deploy-staging:
           type: approval
-          requires:
-            - install-dependencies-and-test
           filters:
             branches:
               only: main
@@ -182,7 +176,6 @@ workflows:
       - assume-role-production:
           context: api-assume-role-regen-apps-production-context
           requires:
-            - install-dependencies-and-test
             - permit-deploy-production
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,11 +155,17 @@ workflows:
       - owasp-zap-baseline-scan:
           requires:
             - install-dependencies-and-test
+      - permit-deploy-staging:
+          type: approval
+          requires:
+            - install-dependencies-and-test
+          filters:
+            branches:
+              only: main
       - assume-role-staging:
           context: api-assume-role-regen-apps-staging-context
           requires:
-            - install-dependencies-and-test
-            - owasp-zap-baseline-scan
+            - permit-deploy-staging
           filters:
             branches:
               only: main


### PR DESCRIPTION
# What:
 - Add a manual permit step before deploying resources to `staging` environment`.
 - Disable application build and scan steps.

# Why:
- So that the resource deployment doesn't trigger pre-maturely.
- Application has been decommissioned no need to build or scan it.
