### PR TITLE
Clear the pipeline workflow and job definitions from any no longer needed steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,39 +20,6 @@ references:
       at: *workspace_root
 
 jobs:
-  owasp-zap-baseline-scan:
-    machine:
-      image: ubuntu-2004:202104-01
-    steps:
-      - checkout
-      - *attach_workspace
-
-      - run:
-          name: Run application in background
-          command: NODE_ENV=production yarn start
-          background: true
-
-      - run:
-          name: Pull owasp zap docker image
-          command: docker pull owasp/zap2docker-stable:2.10.0
-
-      - run:
-          name: ZAP baseline test of application
-          # It will exit with codes of:
-          # 0: Success
-          # 1: At least 1 FAIL
-          # 2: At least one WARN and no FAILs
-          # 3: Any other failure
-          # Link to above:https://github.com/zaproxy/zaproxy/blob/main/docker/zap-baseline.py#L31-L35
-          command: |
-            (
-              docker run -t owasp/zap2docker-stable:2.10.0 zap-baseline.py \
-              -j \
-              -u https://raw.githubusercontent.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}/zap-baseline.conf \
-              -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):3000 || \
-              if [[ $? == 0 || $? == 2 ]]; then exit 0; else exit 1; fi;
-            )
-
   build-deploy-staging:
     executor: aws-cli/default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,6 @@ references:
       at: *workspace_root
 
 jobs:
-  install-dependencies-and-test:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          name: Install dependencies
-          command: exit 0
-
-
   owasp-zap-baseline-scan:
     machine:
       image: ubuntu-2004:202104-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,11 @@ jobs:
           no_output_timeout: 45m
       - run:
           name: add-dependencies
-          command: yarn --production=true && yarn add serverless db-migrate db-migrate-pg
+          command: yarn --production=true && yarn add serverless
       - run:
           name: deploy
           command: yarn deploy --stage staging
           no_output_timeout: 45m
-      - run:
-          name: migrate
-          command: yarn remote:migrate --stage staging
 
   build-deploy-production:
     executor: aws-cli/default
@@ -49,14 +46,11 @@ jobs:
           no_output_timeout: 45m
       - run:
           name: add-dependencies
-          command: yarn --production=true && yarn add serverless db-migrate db-migrate-pg
+          command: yarn --production=true && yarn add serverless
       - run:
           name: deploy
           command: yarn deploy --stage production
           no_output_timeout: 45m
-      - run:
-          name: migrate
-          command: yarn remote:migrate --stage production
 
   assume-role-staging:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn --production=true && yarn add serverless
+          command: yarn add serverless
       - run:
           name: deploy
           command: yarn deploy --stage staging
@@ -38,7 +38,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn --production=true && yarn add serverless
+          command: yarn add serverless
       - run:
           name: deploy
           command: yarn deploy --stage production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies-and-test
       - permit-deploy-staging:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,6 @@ jobs:
     steps:
       - *attach_workspace
       - run:
-          name: build
-          command: yarn build
-          no_output_timeout: 45m
-      - run:
           name: add-dependencies
           command: yarn --production=true && yarn add serverless
       - run:
@@ -40,10 +36,6 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
-      - run:
-          name: build
-          command: yarn build
-          no_output_timeout: 45m
       - run:
           name: add-dependencies
           command: yarn --production=true && yarn add serverless


### PR DESCRIPTION
# What:
 - Remove the no longer needed steps from the pipeline.
 - Remove the no longer needed jobs definitions from the pipeline.

# Why:
 - To make it easier to work with for decommissioning purposes.
 - To prevent any unneeded steps from failing and blocking the pipeline steps that actually matter for the current task.

