### PR TITLE
Attempt making pipeline work with serverless.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn add serverless
+          command: yarn global add serverless
       - run:
           name: deploy
           command: yarn deploy --stage production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn global add serverless
+          command: yarn global add serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage staging
@@ -38,7 +38,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn global add serverless
+          command: yarn global add serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,10 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn add serverless
+          command: yarn global add serverless
       - run:
           name: deploy
-          command: yarn deploy --stage staging
+          command: sls deploy --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:
@@ -41,7 +41,7 @@ jobs:
           command: yarn global add serverless
       - run:
           name: deploy
-          command: yarn deploy --stage production
+          command: sls deploy --stage production
           no_output_timeout: 45m
 
   assume-role-staging:


### PR DESCRIPTION
# What:
 - Install serverless globally rather than as project dependency.
 - Deploy directly via serverless rather than the yarn and possibly some missing yarn script.
 - Cap serverless to major version 3 to stay under unpaid license.

# Why:
 - To make the pipeline work with the serverless framework again.

