### PR TITLE
Use `npm` instead of `yarn` for interacting with serverless.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn global add serverless@^3
+          command: npm i -g serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage staging
@@ -38,7 +38,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: yarn global add serverless@^3
+          command: npm i -g serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: npm i -g serverless@^3
+          command: sudo npm i -g serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage staging
@@ -38,7 +38,7 @@ jobs:
       - *attach_workspace
       - run:
           name: add-dependencies
-          command: npm i -g serverless@^3
+          command: sudo npm i -g serverless@^3
       - run:
           name: deploy
           command: sls deploy --stage production


### PR DESCRIPTION
# What:
 - Use `npm` instead of `yarn` for dealing with serverless.

# Why:
 - For some reason the `sls` is not picked up as a command. Perhaps, with yarn it needs to be called a different way, but we won't guess around this time. There's enough tests to run as is. We're sticking with `npm` as that's what every other pipeline in Hackney does.
