### PR TITLE
Add verbosity and checkout before deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - checkout
       - run:
           name: add-dependencies
           command: sudo npm i -g serverless@^3
@@ -36,6 +37,7 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - checkout
       - run:
           name: add-dependencies
           command: sudo npm i -g serverless@^3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --stage staging
+          command: sls deploy --verbose --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:
@@ -41,7 +41,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --stage production
+          command: sls deploy --verbose --stage production
           no_output_timeout: 45m
 
   assume-role-staging:


### PR DESCRIPTION
# What:
 - Checkout code despite workspace attachment.
 - Add verbosity to the `sls deploy`.

# Why:
 - Chances are the pipeline failed the last time because the attached workspace doesn't contain the actual code files.
 - The serverless errors aren't very informative - verbosity will help with that.