### PR TITLE
Edit delete policies and restrictions for the Postgres RDS Instance and an S3 Bucket.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ resources:
   Resources:
     grantsServiceGrantSupportingDocumentsBucket:
       Type: AWS::S3::Bucket
+      DeletionPolicy: Retain
       Properties:
         BucketName: ${self:custom.bucket}
         PublicAccessBlockConfiguration:

--- a/serverless.yml
+++ b/serverless.yml
@@ -91,7 +91,7 @@ resources:
             Value: ${self:provider.stage}
           - Key: 'Test'
             Value: 'staging-cci-applied'
-      DeletionPolicy: 'Snapshot'
+      DeletionPolicy: Delete
 
 custom:
   dbname: grantsServiceGrantDb

--- a/serverless.yml
+++ b/serverless.yml
@@ -70,7 +70,7 @@ resources:
         DBInstanceIdentifier: '${self:service}-db-${self:provider.stage}'
         DBInstanceClass: 'db.t3.small'
         DBName: ${self:custom.dbname}
-        DeletionProtection: true
+        DeletionProtection: false
         Engine: 'postgres'
         EngineVersion: '11.22'
         CACertificateIdentifier: 'rds-ca-rsa2048-g1'


### PR DESCRIPTION
# What:
 - Remove deletion protection from the Postgres RDS instance.
 - Change deletion policy of Postgres RDS instance to `Delete`.
 - Add deletion policy of Supporting Documents S3 Bucket to `Retain`.

# Why:
 - The Postgres RDS instance on staging hasn't been in use for over 15 months.
 - The Postgres RDS instance on production hasn't been in use for over 7 months.
 - The application itself has been long decommissioned _(PR #93 )_.
 - We can't create the S3 Bucket snapshots, so we'll just keep the bucket as is. As such the retain deletion policy should make the stack deletion skip the S3 bucket deletion.

# Notes:
 - The `staging` postgres RDS snapshot was taken under the name of: `grants-service-db-staging-not-used-in-15mo-manual-snapshot`.
 - The `production` postgres RDS snapshot was taken under the name of: `grants-service-db-production-not-connected-to-for-over-7mo-snapshot`.

# Screenshot

| Staging RDS usage | Production RDS usage |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5512218d-34fc-49b7-958f-3fc048a44ce4) | ![image](https://github.com/user-attachments/assets/73459b79-c476-4269-9070-ecb66de03fa7) |
