### PR TITLE
Retire unsused staging RDS instance & test S3 Bucket Retain policy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --verbose --stage staging
+          command: sls remove --verbose --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:


### PR DESCRIPTION
# What:
 - Trigger the serverless remove for the remaining serverless-managed `staging` resources.
 - Test whether the Retain deletion policy will preserve the S3 Bucket.

# Why:
 - The RDS databases are no longer used & were backed up as snapshots. For more details see: #97.
 - We're testing whether the Retain preserves the bucket on sls remove to explore alternative options of retiring resources.
