### PR TITLE
Install AWS CLI before staging deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - aws-cli/install
       - checkout
       - run:
           name: add-dependencies


### PR DESCRIPTION
# What:
 - Make deploy step install the missing AWS CLI.

# Why:
 - Previous PR #99 changes require AWS CLI, which is not installed by default within the awscli/default executor.