### PR TITLE
Add deployment script to clear out versioned staging S3 bucket files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,23 @@ jobs:
       - run:
           name: clear the S3 bucket
           no_output_timeout: 45m
-          command: aws s3 rm s3://grants-service-supporting-documents-staging --recursive
+          command: |
+            #aws s3 rm s3://grants-service-supporting-documents-staging --recursive
+            # Clear versioned, see: https://docs.aws.amazon.com/cli/latest/reference/s3api/list-object-versions.html#examples
+
+            bucket_name="grants-service-supporting-documents-staging"
+
+            # List all object versions in the bucket and delete them
+            aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
+            while read -r key version_id; do
+              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+            done
+
+            # List all delete markers in the bucket and delete them
+            aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
+            while read -r key version_id; do
+              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+            done
       - run:
           name: delete the empty S3 bucket
           no_output_timeout: 45m


### PR DESCRIPTION
# What:
 - Add script to clear versioned `staging` S3 bucket files.
 - Add script to clear `staging` versioned file markers.

# Why:
 - The bucket cannot be deleted until all the versioned files are deleted.

# Notes:
 - This PR is a continuation of PR #100  and #99 .

# Screenshots:
 | Cannot delete bucket due to file versioning |
 | --- |
 | ![image](https://github.com/user-attachments/assets/95fc7354-8546-4cb7-b93f-aa9870161ee9) |
