### PR TITLE
Use tab internal field separator as the file names contain spaces.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,13 @@ jobs:
 
             # List all object versions in the bucket and delete them
             aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
-            while read -r key version_id; do
+            while IFS=$'\t' read -r key version_id; do
               aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
             done
 
             # List all delete markers in the bucket and delete them
             aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
-            while read -r key version_id; do
+            while IFS=$'\t' read -r key version_id; do
               aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
             done
       - run:


### PR DESCRIPTION
# What:
 - Use tab delimiter to split the values.

# Why:
 - File names contain spaces, which messes up the split.
