### PR TITLE
Remove staging pipeline remnants & prepare it for production deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,40 +20,6 @@ references:
       at: *workspace_root
 
 jobs:
-  deploy-staging:
-    executor: aws-cli/default
-    steps:
-      - *attach_workspace
-      - aws-cli/install
-      - checkout
-      - run:
-          name: add-dependencies
-          command: sudo npm i -g serverless@^3
-      - run:
-          name: clear the S3 bucket
-          no_output_timeout: 45m
-          command: |
-            #aws s3 rm s3://grants-service-supporting-documents-staging --recursive
-            # Clear versioned, see: https://docs.aws.amazon.com/cli/latest/reference/s3api/list-object-versions.html#examples
-
-            bucket_name="grants-service-supporting-documents-staging"
-
-            # List all object versions in the bucket and delete them
-            aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
-            while IFS=$'\t' read -r key version_id; do
-              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
-            done
-
-            # List all delete markers in the bucket and delete them
-            aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
-            while IFS=$'\t' read -r key version_id; do
-              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
-            done
-      - run:
-          name: delete the empty S3 bucket
-          no_output_timeout: 45m
-          command: aws s3api delete-bucket --bucket grants-service-supporting-documents-staging
-
   build-deploy-production:
     executor: aws-cli/default
     steps:
@@ -66,19 +32,6 @@ jobs:
           name: deploy
           command: sls deploy --verbose --stage production
           no_output_timeout: 45m
-
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - checkout
-      - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_STAGING
-          profile_name: default
-          role: 'LBH_Circle_CI_Deployment_Role'
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
 
   assume-role-production:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,9 @@ workflows:
     jobs:
       - permit-deploy-production:
           type: approval
+          filters:
+            branches:
+              only: main
       - assume-role-production:
           context: api-assume-role-regen-apps-production-context
           requires:
@@ -109,3 +112,6 @@ workflows:
       - build-deploy-production:
           requires:
             - assume-role-production
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,28 +97,8 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - permit-deploy-staging:
-          type: approval
-          filters:
-            branches:
-              only: main
-      - assume-role-staging:
-          context: api-assume-role-regen-apps-staging-context
-          requires:
-            - permit-deploy-staging
-          filters:
-            branches:
-              only: main
-      - deploy-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: main
       - permit-deploy-production:
           type: approval
-          requires:
-            - deploy-staging
       - assume-role-production:
           context: api-assume-role-regen-apps-production-context
           requires:


### PR DESCRIPTION
# What:
 - Remove `staging` pipeline's job definitions & their references within workflow.

# Why:
 - We've retired the `staging` environment on `Regen-Apps-Staging` account.

# Notes:
**Clean up after PRs:**
- #93 
- #97 
- #98 