### PR TITLE
Remove staging references from serverless.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -98,10 +98,7 @@ custom:
   dbname: grantsServiceGrantDb
   bucket: ${self:service}-supporting-documents-${self:provider.stage}
   vpc-id:
-    staging: vpc-0047c1ec06d524b64
     production: vpc-0c9c2cbf1865adb9e
   subnets:
-    staging-1: subnet-034d259953e54531a
-    staging-2: subnet-0e0152a2fc2b42498
     production-1: subnet-056356c011224f114
     production-2: subnet-067865bb76395b74e


### PR DESCRIPTION
# What:
 - Remove `staging` VPC and subnet references from serverless file.

# Notes:
 - This PR will trigger the deletion of lambda related resources, see PR #93 .
 - This PR will also deploy the Deletion Policy to retain the supporting documents S3 bucket, see PR #97.

# Why:
 - Changes behind this PR are an excuse for a dedicated PR due to all the work apparently having already been done.
 - We're deleting the lambda resources because the application has long been decommissioned.
 - We're want to preserve the S3 bucket as the it was indicated that we want to keep the data.