### PR TITLE
Retire `Regen-Apps-Production` environment resources, except the S3 supporting docs bucket.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --verbose --stage production
+          command: sls remove --verbose --stage production
           no_output_timeout: 45m
 
   assume-role-production:


### PR DESCRIPTION
# What:
 - Retire `Regen-Apps-Production` grants-service-production CloudFormation stack resources _(except S3)_.

# Why:
 - The application has been long decommissioned _(See screenshots on PR # )_.

# Notes:
 - The S3 will not be destroyed & will get de'associated from the stack due to previously deployed [Retain](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) policy PR # .
 - The RDS instance will be destroyed, but it was backed up under the snapshot name: `grants-service-db-production-not-connected-to-for-over-7mo-snapshot`.

# Screenshot:

| S3 bucket has Retain policy |
| --- |
| ![image](https://github.com/user-attachments/assets/e95acdce-1dd7-43ab-aaae-1020785d0d16) |